### PR TITLE
Remove unneeded condition.

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -77,20 +77,16 @@ class User extends Authenticatable
      */
     public function follow(User $user)
     {
-        if (! $this->checkFollowing($user->id)) {
-            $user->followers()->attach($this->id);
-        }
+        $user->followers()->syncWithoutDetaching($this->id);
 
         //event(new UserFollowedAnotherUser($user));
 
         return $user;
     }
 
-    public function unFollow(User $user)
+    public function unfollow(User $user)
     {
-        if ($this->checkFollowing($user->id)) {
-            $user->followers()->detach($this->id);
-        }
+        $user->followers()->detach($this->id);
 
         //event(new UserUnFollowedAnotherUser($user));
 


### PR DESCRIPTION
For `follow`, let laravel do this for you. `$user->followers()->sync($this->id, false);` works too.

For `unFollow`, remove the conditional and it will still work fine. If you need to know if anything was deleted, `detach` uses `delete` under the hood and returns the number of rows affected.

I would also rename `unFollow` to `unfollow`.