### PR TITLE
`getIsFollowedByAuthAttribute`

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -114,15 +114,6 @@ class User extends Authenticatable
         return $user->slug;
     }
 
-    public function getIsFollowedByAuthAttribute()
-    {
-        if(!Auth::user()) return false;
-
-        if (Auth::user()->checkFollowing($this->id)) {
-            return true;
-        };
-    }
-
     /**
      * Get the path to the user's avatar.
      *


### PR DESCRIPTION
I'm not sure I like this in here. Where you do `$user->getIsFollowedByAuthAttribute()` you could just do `optional(Auth::check())->checkFollowing($user);` instead, and it will return `null` instead of `false` when not authenticated, giving you more possibilities. Look into `optional` it's quite powerfull here and there.